### PR TITLE
Add oklog to the list of DevOps Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1388,6 +1388,7 @@ Software written in Go.
 * [kala](https://github.com/ajvb/kala) - Simplistic, modern, and performant job scheduler.
 * [kubernetes](https://github.com/kubernetes/kubernetes) - Container Cluster Manager from Google.
 * [Mora](https://github.com/emicklei/mora) - REST server for accessing MongoDB documents and meta data.
+* [oklog](https://github.com/oklog/oklog) - A distributed and coördination-free log management system.
 * [ostent](https://github.com/ostrost/ostent) - collects and displays system metrics and optionally relays to Graphite and/or InfluxDB.
 * [Packer](https://github.com/mitchellh/packer) - Packer is a tool for creating identical machine images for multiple platforms from a single source configuration.
 * [Pewpew](https://github.com/bengadbois/pewpew) - Flexible HTTP command line stress tester.


### PR DESCRIPTION
**Please provide package links to:**
- github.com repo: https://github.com/oklog/oklog
- godoc.org: https://godoc.org/github.com/oklog/oklog
- goreportcard.com: https://goreportcard.com/report/github.com/oklog/oklog
- coverage service link: https://gocover.io/github.com/oklog/oklog/cmd/oklog (most code is in packages under /pkg/*, in various states of coverage completion)

**Make sure that you've checked the boxes below before you submit PR:**
- [x] I have added my package in alphabetical order
- [x] I know that this package was not listed before
- [x] I have added godoc link to the repo and to my pull request
- [x] I have added coverage service link to the repo and to my pull request
- [x] I have added goreportcard link to the repo and to my pull request
- [x] I have read [Contribution guidelines](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#contribution-guidelines) and [Quality standard](https://github.com/avelino/awesome-go/blob/master/CONTRIBUTING.md#quality-standard).

